### PR TITLE
feat: フレーズ段階別シミュレーション表示を追加

### DIFF
--- a/crates/gf-skill-sim/src/main.rs
+++ b/crates/gf-skill-sim/src/main.rs
@@ -376,5 +376,42 @@ fn main() -> Result<()> {
         }
     }
 
+    // フレーズ段階別シミュレーション
+    if args.phrase_total > 0 {
+        println!();
+        println!(
+            "=== フレーズ別シミュレーション (現在: {}/{}) ===",
+            args.phrase_success, args.phrase_total
+        );
+        let width = format!("{}", args.phrase_total).len();
+        for i in 0..=args.phrase_total {
+            let ach = calc_achievement(
+                args.perfect,
+                args.great,
+                args.notes,
+                args.combo,
+                i,
+                args.phrase_total,
+            );
+            let skill = calc_skill(args.level, ach);
+            let mark = status_mark(skill, args.target);
+            let current = if i == args.phrase_success {
+                "  <- 現在"
+            } else {
+                ""
+            };
+            println!(
+                "  [{}] {:>w$}/{:<w$}  達成率 {:.2}%  スキル {:.2}{}",
+                mark,
+                i,
+                args.phrase_total,
+                ach,
+                skill,
+                current,
+                w = width
+            );
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

- フレーズ 0/N〜N/N の全段階でのスキルポイントを一覧表示するセクションを追加
- 現在の段階に `<- 現在` マークを表示
- 各段階に `[OK]`/`[--]` で目標達成可否を表示
- フレーズが下がっても他の要素で目標に届くケースの確認に対応

Closes #6

## Test plan

- [x] `cargo build --package gf-skill-sim` でビルド成功
- [x] フレーズ 3/6 のケースで 0/6〜6/6 の全段階が表示されることを確認
- [x] 現在の段階に `<- 現在` が付くことを確認
- [x] 目標達成可能な段階に `[OK]` が付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)