### PR TITLE
feat: CI成功時のDiscord Webhook通知を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,13 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test --all
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          if [ -n "$DISCORD_WEBHOOK" ]; then
+            curl -fsSL -H "Content-Type: application/json" \
+              -d "{\"content\": \"✅ CI passed: **${{ github.repository }}** (\`${{ github.ref_name }}\`) by ${{ github.actor }}\\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+              "$DISCORD_WEBHOOK"
+          fi


### PR DESCRIPTION
## Summary

- CI 全ステップ成功時に Discord へ curl で通知するステップを追加
- `DISCORD_WEBHOOK` シークレット未設定時はスキップ（CI は正常完了）
- メッセージにリポジトリ名、ブランチ名、実行者、Actions URL を含む

Closes #10
Related to #9

## 手動セットアップ

1. Discord チャンネルで Webhook URL を作成
2. GitHub リポジトリ Settings → Secrets and variables → Actions → `DISCORD_WEBHOOK` を登録

## Test plan

- [x] `DISCORD_WEBHOOK` 未設定でも CI が失敗しないことを確認（if ガード）
- [ ] `DISCORD_WEBHOOK` 設定後、CI 成功時に Discord に通知が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)