### PR TITLE
feat: Discord通知にPR URLを含める

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
           if [ -n "$DISCORD_WEBHOOK" ]; then
+            PR_URL="${{ github.event.pull_request.html_url }}"
+            if [ -n "$PR_URL" ]; then
+              MSG="✅ CI passed: **${{ github.repository }}** (\`${{ github.ref_name }}\`) by ${{ github.actor }}\n${PR_URL}"
+            else
+              MSG="✅ CI passed: **${{ github.repository }}** (\`${{ github.ref_name }}\`) by ${{ github.actor }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            fi
             curl -fsSL -H "Content-Type: application/json" \
-              -d "{\"content\": \"✅ CI passed: **${{ github.repository }}** (\`${{ github.ref_name }}\`) by ${{ github.actor }}\\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+              -d "{\"content\": \"${MSG}\"}" \
               "$DISCORD_WEBHOOK"
           fi


### PR DESCRIPTION
## Summary

- PRイベント時: PR の URL を通知に含める
- pushイベント時（main直push）: 従来通り Actions の URL を含める

## Test plan

- [ ] PRのCIで Discord 通知に PR URL が含まれることを確認
- [ ] main push 時は Actions URL が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)