### PR TITLE
feat: ダイスコマンド追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +115,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "dice"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rand",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gf-skill-sim"
 version = "0.1.0"
 dependencies = [
@@ -129,10 +156,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -150,6 +192,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -182,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,4 +280,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/crates/dice/Cargo.toml
+++ b/crates/dice/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dice"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { workspace = true }
+anyhow = { workspace = true }
+rand = "0.9"

--- a/crates/dice/src/main.rs
+++ b/crates/dice/src/main.rs
@@ -1,0 +1,69 @@
+use anyhow::{bail, Result};
+use clap::Parser;
+use rand::Rng;
+
+#[derive(Parser)]
+#[command(name = "dice", about = "NdM 形式でダイスを振る")]
+struct Args {
+    /// ダイス指定 (例: 2d6, 1d20, 3d8)
+    dice: String,
+}
+
+fn parse_dice(s: &str) -> Result<(u32, u32)> {
+    let s = s.to_lowercase();
+    let parts: Vec<&str> = s.split('d').collect();
+    if parts.len() != 2 {
+        bail!("NdM 形式で指定してください (例: 2d6)");
+    }
+    let count: u32 = parts[0].parse().unwrap_or(0);
+    let sides: u32 = parts[1].parse().unwrap_or(0);
+    if count == 0 || sides == 0 {
+        bail!("ダイスの個数と面数は1以上で指定してください");
+    }
+    Ok((count, sides))
+}
+
+fn roll(count: u32, sides: u32) -> Vec<u32> {
+    let mut rng = rand::rng();
+    (0..count).map(|_| rng.random_range(1..=sides)).collect()
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let (count, sides) = parse_dice(&args.dice)?;
+    let results = roll(count, sides);
+    let total: u32 = results.iter().sum();
+    println!("🎲 {}: {:?} = {}", args.dice, results, total);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid() {
+        assert_eq!(parse_dice("2d6").unwrap(), (2, 6));
+        assert_eq!(parse_dice("1d20").unwrap(), (1, 20));
+        assert_eq!(parse_dice("3D8").unwrap(), (3, 8));
+    }
+
+    #[test]
+    fn parse_invalid() {
+        assert!(parse_dice("abc").is_err());
+        assert!(parse_dice("0d6").is_err());
+        assert!(parse_dice("2d0").is_err());
+        assert!(parse_dice("d6").is_err());
+    }
+
+    #[test]
+    fn roll_range() {
+        for _ in 0..100 {
+            let results = roll(3, 6);
+            assert_eq!(results.len(), 3);
+            for &r in &results {
+                assert!((1..=6).contains(&r));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- NdM 形式でダイスを振る CLI ツール `dice` を追加
- `dice 2d6` → `🎲 2d6: [3, 5] = 8`
- パース、ロール範囲のユニットテスト付き

Closes #15

## Test plan

- [x] `cargo test --package dice` で 3 テスト pass
- [x] `cargo clippy` pass
- [x] `dice 2d6`, `dice 1d20`, `dice 3d8` の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)