### PR TITLE
fix: Discord通知から /new を削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           if [ -n "$DISCORD_WEBHOOK" ]; then
             PR_URL="${{ github.event.pull_request.html_url }}"
             if [ -n "$PR_URL" ]; then
-              MSG="/new ✅ CI Passed! @saya Please review: ${PR_URL}"
+              MSG="✅ CI Passed! @saya Please review: ${PR_URL}"
             else
-              MSG="/new ✅ CI Passed! @saya Please review: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              MSG="✅ CI Passed! @saya Please review: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             fi
             curl -fsSL -H "Content-Type: application/json" \
               -d "{\"content\": \"${MSG}\"}" \


### PR DESCRIPTION
## Summary

- Discord通知メッセージから `/new` プレフィックスを削除
- `✅ CI Passed! @saya Please review: {PR URL}` になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)